### PR TITLE
Support direct binding of IDictionary model types

### DIFF
--- a/Extensions/DefaultDictionaryBinder.cs
+++ b/Extensions/DefaultDictionaryBinder.cs
@@ -50,7 +50,16 @@ using System.ComponentModel;
         public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
         {
             Type modelType = bindingContext.ModelType;
-            Type idictType = modelType.GetInterface("System.Collections.Generic.IDictionary`2");
+            Type idictType;
+            
+            if (modelType.FullName.StartsWith("System.Collections.Generic.IDictionary`2"))
+            {
+                idictType = modelType;
+            }
+            else
+            {
+                idictType = modelType.GetInterface("System.Collections.Generic.IDictionary`2");
+            }
             if (idictType != null)
             {
                 object result = null;


### PR DESCRIPTION
The original code would skip over the model if the model itself was IDictionary type, since 
the interface won't have itself listed as an interface.

MVC's default binder (at least, in the version I've used) is able to bind to the interface,
and assumes the Dictionary implementation, so having it supported by this binder is nice.

With this change, this works:

```
public ActionResult DoAThing(IDictionary<int, string> modelValues) { ... }
```
